### PR TITLE
Verify opt125m tensor parallelism

### DIFF
--- a/src/tensor_parallel_keras/config_keras.py
+++ b/src/tensor_parallel_keras/config_keras.py
@@ -5,7 +5,6 @@ Configuration classes for Keras Tensor Parallel
 import dataclasses
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
-import torch
 from keras import layers
 
 from .communications_keras import AllReduceKeras, AllGatherKeras, BroadcastKeras


### PR DESCRIPTION
Fix `TensorParallelKeras.train_step` signature and make `torch` imports optional for JAX backend compatibility.

The `train_step` method was failing due to an incorrect signature and data unpacking when `sample_weight` was provided by Keras's `fit` method. Additionally, `torch` was unconditionally imported in `config_keras.py` and `coordinated_optimizer.py`, preventing JAX-only environments from running without PyTorch installed. This PR resolves these issues by making `train_step` robust to various input formats and guarding `torch` imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c44c8db-834a-44ce-a462-2e8757eb867e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c44c8db-834a-44ce-a462-2e8757eb867e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

